### PR TITLE
Updates based on PR comments

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -5,22 +5,16 @@ use crate::error::AnyError;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct Usage {
-    pub prompt_tokens: i64,
-    pub completion_tokens: i64,
-    pub total_tokens: i64,
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
-pub struct MessageResponse {
-    pub role: String,
-    pub content: String,
+    pub prompt_tokens: i32,
+    pub completion_tokens: i32,
+    pub total_tokens: i32,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct Choice {
-    pub message: MessageResponse,
+    pub message: Message,
     pub finish_reason: String,
-    pub index: i64,
+    pub index: usize,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -89,12 +83,12 @@ impl Model {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
-pub struct MessageRequest {
+pub struct Message {
     pub role: String,
     pub content: String,
 }
 
-impl MessageRequest {
+impl Message {
     pub fn new(content: &str) -> Self {
         Self {
             role: "user".to_owned(),
@@ -106,14 +100,14 @@ impl MessageRequest {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct Payload {
     pub model: Model,
-    pub messages: Vec<MessageRequest>,
+    pub messages: Vec<Message>,
 }
 
 impl Payload {
     pub fn new(model: &str, content: &str) -> Result<Self, AnyError> {
         Ok(Self {
             model: Model::new(model)?,
-            messages: vec![MessageRequest::new(content)],
+            messages: vec![Message::new(content)],
         })
     }
 }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -43,7 +43,7 @@ pub struct ErrorResponse {
 impl From<ErrorResponse> for String {
     fn from(value: ErrorResponse) -> Self {
         format!(
-            "Error: {} {} {} {}",
+            "{} {} {} {}",
             value.error.message, value.error.r#type, value.error.param, value.error.code
         )
     }
@@ -77,7 +77,7 @@ impl Model {
         match model {
             "gpt-3.5-turbo" => Ok(Self::Gpt3Turbo),
             "gpt-4" => Ok(Self::Gpt4),
-            _ => Err("Error: Not a valid model name".into()),
+            _ => Err("Not a valid model name".into()),
         }
     }
 }
@@ -150,7 +150,7 @@ pub fn post(args: &Args) -> Result<String, AnyError> {
     let client = builder
         .timeout(timeout)
         .build()
-        .map_err(|_| "Error: could not create HTTP client")?;
+        .map_err(|_| "Could not create HTTP client")?;
 
     let payload = Payload::new(args.model_name, args.message)?;
     let token: String = BearerToken::new(args.api_key).into();
@@ -165,11 +165,11 @@ pub fn post(args: &Args) -> Result<String, AnyError> {
         .header("Authorization", token)
         .json(&payload)
         .send()
-        .map_err(|error| format!("Error: could not send request to ChatGPT API\n  {}", error))?;
+        .map_err(|error| format!("Could not send request to ChatGPT API\n  {}", error))?;
 
     let response = response
         .json::<Response>()
-        .map_err(|_| "Error: could not parse response from ChatGPT API")?;
+        .map_err(|_| "Could not parse response from ChatGPT API")?;
 
     match response {
         Response::Error(message) => {
@@ -178,7 +178,7 @@ pub fn post(args: &Args) -> Result<String, AnyError> {
         }
         Response::Success(message) => {
             let last_choice = message.choices.last();
-            let choice = last_choice.ok_or("Error: no text found in response from ChatGPT API")?;
+            let choice = last_choice.ok_or("No text found in response from ChatGPT API")?;
 
             Ok(choice.message.content.trim().to_owned())
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 extern crate serde_json;
 
-use clap::Parser;
 use crate::error::AnyError;
+use clap::Parser;
 
 pub mod chat;
 pub mod cli;
@@ -20,11 +20,15 @@ fn main() -> Result<(), AnyError> {
         debug: &cli.debug,
     })?;
 
-    if cli.in_place && cli.input.is_some() {
-        file::write(&cli.input.unwrap(), response.as_bytes())?;
-    } else {
+    if !cli.in_place && cli.input.is_none() {
         println!("{}", response);
+        return Ok(());
     }
 
-    Ok(())
+    if cli.in_place && cli.input.is_some() {
+        file::write(&cli.input.unwrap(), response.as_bytes())?;
+        return Ok(());
+    }
+
+    Err("Cannot use --in-place without file input".into())
 }


### PR DESCRIPTION
- Reduced to one `Message` struct in the chat module
- Added errors for usage of `--in-place` without file input
- Used `i32` where appropriate and `usize` for index
- Removed `Error:` from messages since result types include this